### PR TITLE
Add Message ID to recent message name

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 				parseMessageToHtml(message, loadAndAttachDefinition);
 				
 				// Compose a name for the message
-				var name = getValueByHl7Path("MSH.9.1") + " " + getValueByHl7Path("MSH.9.2") + " - " + getValueByHl7Path("MSH.3") + " " + getValueByHl7Path("MSH.4");
+				var name = getValueByHl7Path("MSH.10") + ": " + getValueByHl7Path("MSH.9.1") + " " + getValueByHl7Path("MSH.9.2") + " - " + getValueByHl7Path("MSH.3") + " " + getValueByHl7Path("MSH.4");
 				if (name == null) {
 					name = "Message"; // TODO come up with a better name
 				}

--- a/resources/js/parser.js
+++ b/resources/js/parser.js
@@ -140,7 +140,7 @@ function splitMessage(separators, separatorIndex, content, container) {
 }
 
 function getValueByHl7Path(path) {
-	var regex = /^([A-Z]{3})(\[\d+\])?((\.\d)+)/i
+	var regex = /^([A-Z]{3})(\[\d+\])?((\.\d+))/i
 	var match = regex.exec(path);
 	if (match == null) {
 		return null;


### PR DESCRIPTION
Added MSH.10 to the recent messages name. While doing this discovered a bug in the parser field path regex. Fixed this as well.